### PR TITLE
V0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.2 (2022-12-26)
+
+- 952ccd8 fix: assign default node version
+- e4773cb feat: export `type Plugin`
+
 ## 0.3.1 (2022-12-25)
 
 - f804b6d fix: sourcemap warn

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ watch(config)
 
 ```ts
 import {
+  type Plugin,
   type Configuration,
   type ResolvedConfig,
   resolveConfig,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notbundle",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Inspired by Vite's Not Bundle, building ts for use in Node.js.",
   "main": "index.js",
   "types": "types",
@@ -15,8 +15,8 @@
   "license": "MIT",
   "scripts": {
     "dev": "vite build --watch",
-    "build": "rm -rf types && tsc --emitDeclarationOnly && vite build && npm run test",
-    "prepublishOnly": "npm run build",
+    "build": "rm -rf types && tsc --emitDeclarationOnly && vite build",
+    "prepublishOnly": "npm run test && npm run build",
     "test": "vitest run"
   },
   "peerDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export {
+  type Plugin,
   type Configuration,
   type ResolvedConfig,
   resolveConfig,

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -24,7 +24,7 @@ function swc(): Plugin {
       const transformOptions = _config.transformOptions
       transformOptions.env ??= {}
       transformOptions.env.targets ??= {}
-      transformOptions.env.targets.node = '14'
+      transformOptions.env.targets.node ??= '14'
       transformOptions.module ??= { type: 'commonjs' }
     },
     async transform({ filename, code }) {


### PR DESCRIPTION
## 0.3.2 (2022-12-26)

- 952ccd8 fix: assign default node version
- e4773cb feat: export `type Plugin`